### PR TITLE
fix PUBLIC_URL

### DIFF
--- a/build-manager/Dockerfile
+++ b/build-manager/Dockerfile
@@ -6,7 +6,7 @@ ARG REACT_APP_BASE_SIGNING_URL
 
 RUN apk add bash git \
     && git clone https://github.com/GridPlus/lattice-manager.git /opt/lattice \
-    && npm install && npm run build && npm install -g serve
+    && npm install && PUBLIC_URL='.' npm run build && npm install -g serve
 
 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 


### PR DESCRIPTION
Recently `homepage` was added to package.json of lattice-manager, resulting in PUBLIC_URL pointing to `/lattice-manager/`. This breaks asset links when deploying at a different location (e.g. dappnode). This change makes sure to reset the PUBLIC_URL when building for dappnode.